### PR TITLE
docker-compose doesn't read env by default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,3 +5,4 @@ services:
     build: .
     container_name: bambot
     restart: always
+    env_file: .env


### PR DESCRIPTION
Despite Docker Compose documentation saying it supports loading environment
variables from .env file, it still needed to be specified explicitly.